### PR TITLE
Bugfix: too many matlab custom controller instances

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -23,10 +23,8 @@ Mode::Mode(void) :
     channel_throttle(copter.channel_throttle),
     channel_yaw(copter.channel_yaw),
     G_Dt(copter.G_Dt)
-    #ifdef Custom_Matlab_Output
-    ,socket_debug(true)
-    #endif
-{ };
+{
+}
 
 // return the static controller object corresponding to supplied mode
 Mode *Copter::mode_from_mode_num(const Mode::Number mode)

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1,6 +1,7 @@
 #pragma once
 
 //#define CUSTOM_MATLAB_OUTPUT //define for the custom simulink output
+//#define CUSTOM_MATLAB_INDOOR_TESTING
 
 #include "Copter.h"
 #include <AC_AttitudeControl/MatlabController.h>    // new
@@ -1403,7 +1404,11 @@ public:
     bool init(bool ignore_checks) override;
     virtual void run() override;
 
+#ifdef CUSTOM_MATLAB_INDOOR_TESTING
+    bool requires_GPS() const override { return false; }
+#else
     bool requires_GPS() const override { return true; }
+#endif
     bool has_manual_throttle() const override { return true; }
     bool allows_arming(AP_Arming::Method method) const override { return true; };
     bool is_autopilot() const override { return false; }

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1,10 +1,11 @@
 #pragma once
 
-//#define Custom_Matlab_Output //define for the custom simulink output
+//#define CUSTOM_MATLAB_OUTPUT //define for the custom simulink output
 
 #include "Copter.h"
 #include <AC_AttitudeControl/MatlabController.h>    // new
-#ifdef Custom_Matlab_Output
+
+#ifdef CUSTOM_MATLAB_OUTPUT
     #include <AP_HAL/utility/Socket.h>
 #endif
 
@@ -175,13 +176,6 @@ protected:
     RC_Channel *&channel_throttle;
     RC_Channel *&channel_yaw;
     float &G_Dt;
-
-    MatlabControllerClass custom_controller;
-#ifdef Custom_Matlab_Output
-    SocketAPM socket_debug; //
-    const char *_debug_address = "127.0.0.1";
-    int _debug_port = 9004;
-#endif
 
     // note that we support two entirely different automatic takeoffs:
 
@@ -1396,8 +1390,14 @@ private:
 class ModeCustom : public Mode {
 
 public:
+
+#ifdef CUSTOM_MATLAB_OUTPUT
+    ModeCustom(void);
+#else
     // inherit constructor
     using Mode::Mode;
+#endif
+
     Number mode_number() const override { return Number::CUSTOM; }
 
     bool init(bool ignore_checks) override;
@@ -1421,6 +1421,14 @@ protected:
     void override_cntrl_params();
 
 private:
+    MatlabControllerClass custom_controller;
+
+#ifdef CUSTOM_MATLAB_OUTPUT
+    SocketAPM socket_debug;
+    const char *_debug_address = "127.0.0.1";
+    int _debug_port = 9004;
+#endif
+
     static const int max_num_of_matlab_waypoints = 6;
     // Ardupilot contains ghost waypoints
     // (home position and velocity of previous waypoint),

--- a/ArduCopter/mode_custom.cpp
+++ b/ArduCopter/mode_custom.cpp
@@ -2,6 +2,13 @@
 #include <AP_Motors/AP_MotorsMatrix.h>
 #include <GCS_MAVLink/GCS.h>
 
+#ifdef CUSTOM_MATLAB_OUTPUT
+// constructor
+ModeCustom::ModeCustom(void) : Mode(), socket_debug(true)
+{
+}
+#endif
+
 // Function for hardcoding changes to MATLABs cntrl struct.
 // Values can be accessed in the same fashion as in MATLAB, e.g.:
 //     cntrl.sample_time = 42;
@@ -229,8 +236,8 @@ void ModeCustom::run()
     // DEBUGGING:
     // Send all inputs of custom controller to Simulink (uncomment line 3 in mode.h)
     // Check byte alignment/padding in Simulink, while receiving (e.g. 4)
-    #ifdef Custom_Matlab_Output
-        socket_debug.sendto(&rtU_.measure, sizeof(rtU_), _debug_address, _debug_port); 
+    #ifdef CUSTOM_MATLAB_OUTPUT
+        socket_debug.sendto(&rtU_.measure, sizeof(rtU_), _debug_address, _debug_port);
     #endif
 
     // log signals


### PR DESCRIPTION
**Fix too many MatlabControllerClass instances**

'custom_controller' (instance of class 'MatlabControllerClass')
was member of class 'Mode'. This is not desired, because the
class 'Mode' is the base class for all derived flight mode classes.
In this way each flight mode instance also contained an instance of
'MatlabControllerClass' which means that there were as many
instances of 'MatlabControllerClass' as flight modes in ArduPilot.

'custom_controller' is now a private member of the derived class
'ModeCustom' and also the optional debugging socket has been placed here.

Also added an additional preprocessor directive to be able to disable
GPS in ModeCustom for indoor testing.