### PR TITLE
Fix too many MatlabControllerClass instances

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -8,9 +8,6 @@ Mode::Mode()
     loiter_nav(plane.quadplane.loiter_nav),
     poscontrol(plane.quadplane.poscontrol)
 #endif
-    #ifdef Custom_Matlab_Output
-    ,socket_debug(true)
-    #endif
 {
 }
 

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// #define Custom_Matlab_Output //define for the custom simulink output
+// #define CUSTOM_MATLAB_OUTPUT //define for the custom simulink output
 #define Custom_Debug // print performance to console
 // #define Mode_Custom_Use_External_Controller
 
@@ -12,7 +12,7 @@
 #include <AP_Vehicle/ModeReason.h>
 #include "quadplane.h"
 #include <AP_Common/MatlabController.h>
-#ifdef Custom_Matlab_Output
+#ifdef CUSTOM_MATLAB_OUTPUT
     #include <AP_HAL/utility/Socket.h>
 #endif
 
@@ -145,13 +145,6 @@ protected:
     AC_Loiter*& loiter_nav;
     QuadPlane& quadplane;
     QuadPlane::PosControlState &poscontrol;
-#endif
-
-    MatlabControllerClass custom_controller;
-#ifdef Custom_Matlab_Output
-    SocketAPM socket_debug; //
-    const char *_debug_address = "127.0.0.1";
-    int _debug_port = 9004;
 #endif
 };
 
@@ -334,6 +327,13 @@ class ModeCustom : public Mode //added
 {
 public:
 
+    #ifdef CUSTOM_MATLAB_OUTPUT
+        ModeCustom(void);
+    #else
+        // inherit constructor
+        using Mode::Mode;
+    #endif
+
     Number mode_number() const override { return Number::CUSTOM; }
     const char* name() const override { return "CUSTOM"; }
     const char* name4() const override { return "CUSTOM"; }
@@ -384,6 +384,16 @@ protected:
     #ifdef Mode_Custom_Use_External_Controller
         void step_external();
     #endif
+
+private:
+
+    MatlabControllerClass custom_controller;
+
+#ifdef CUSTOM_MATLAB_OUTPUT
+    SocketAPM socket_debug; //
+    const char *_debug_address = "127.0.0.1";
+    int _debug_port = 9004;
+#endif
 };
 
 class ModeRTL : public Mode

--- a/ArduPlane/mode_custom.cpp
+++ b/ArduPlane/mode_custom.cpp
@@ -11,6 +11,15 @@
     uint16_t missed_frames = 0;
 #endif
 
+
+#ifdef CUSTOM_MATLAB_OUTPUT
+// constructor
+ModeCustom::ModeCustom(void) : Mode(), socket_debug(true)
+{
+}
+#endif
+
+
 bool ModeCustom::_enter()
 {
     #ifdef Mode_Custom_Use_External_Controller
@@ -187,7 +196,7 @@ void ModeCustom::update()
     // DEBUGGING:
     // Send all inputs of custom controller to Simulink (uncomment line 3 in mode.h)
     // Check byte alignment/padding in Simulink, while receiving (e.g. 4)
-    #ifdef Custom_Matlab_Output
+    #ifdef CUSTOM_MATLAB_OUTPUT
         socket_debug.sendto(rtU_, sizeof(ExtU), _debug_address, _debug_port); 
     #endif
 


### PR DESCRIPTION
'custom_controller' (instance of class 'MatlabControllerClass') was member of class 'Mode'. This is not desired, because the class 'Mode' is the base class for all derived flight mode classes. In this way each flight mode instance also contained an instance of 'MatlabControllerClass' which means that there were as many instances of 'MatlabControllerClass' as flight modes in ArduPilot.

'custom_controller' is now a private member of the derived class 'ModeCustom' and also the optional debugging socket has been placed here.

See also: 911cfe2c